### PR TITLE
Fix detection CustomEvent

### DIFF
--- a/custom-event-polyfill.js
+++ b/custom-event-polyfill.js
@@ -5,7 +5,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#Polyfill
 
 try {
-  new CustomEvent("test");
+  new window.CustomEvent("test");
 } catch(e) {
  var CustomEvent = function(event, params) {
       var evt;


### PR DESCRIPTION
We use polyfill with 'require' and we have problems with detection CustomEvent in Chrome.