### PR TITLE
Fix defaultprevented for IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "karma start"
   },
   "devDependencies": {
+    "jasmine-core": "^2.4.1",
     "karma": "^0.12.31",
     "karma-jasmine": "^0.3.5",
     "karma-sauce-launcher": "^0.2.10"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "Mozilla Developer Network",
     "Evan Krambuhl <thekrambuhl@gmail.com>"
   ],
+  "license": "MIT",
   "keywords": [
     "polyfill",
     "custom-event",

--- a/tests/customevent.test.js
+++ b/tests/customevent.test.js
@@ -11,4 +11,10 @@ describe('custom-event-polyfill', function () {
     var ev = new CustomEvent('test', { detail: 'blammy' });
     expect(ev.detail).toEqual('blammy');
   });
+
+  it('should be possible to call .preventDefault', function() {
+    var ev = new CustomEvent('test', { cancelable: true });
+    ev.preventDefault();
+    expect(ev.defaultPrevented).toEqual(true);
+  });
 });


### PR DESCRIPTION
Using `.preventDefault()` on a CustomEvent in IE causes problems, see here: http://stackoverflow.com/questions/23349191

This PR adds a fix for this.