### PR TITLE
Expose CustomEvent as Event

### DIFF
--- a/custom-event-polyfill.js
+++ b/custom-event-polyfill.js
@@ -41,4 +41,7 @@ try {
 
   CustomEvent.prototype = window.Event.prototype;
   window.CustomEvent = CustomEvent; // expose definition to window
+  if(typeof Event !== 'function') {
+    window.Event = CustomEvent;
+  }
 }

--- a/custom-event-polyfill.js
+++ b/custom-event-polyfill.js
@@ -41,7 +41,7 @@ try {
 
   CustomEvent.prototype = window.Event.prototype;
   window.CustomEvent = CustomEvent; // expose definition to window
-  if(typeof Event !== 'function') {
+  if(typeof window.Event !== 'function') {
     window.Event = CustomEvent;
   }
 }


### PR DESCRIPTION
IE11 (and maybe older versions as well) on `new Event()` would fail with:
```
Object doesn't support this action
```

this resolves the issue.